### PR TITLE
Fix dest volume path with custom input.src

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
         options: |
           -v ${{ github.workspace }}:/home/logseq/graph -v ${{ github.workspace }}/${{ inputs.dest }}:/home/logseq/graph-www
         run: |
-          xvfb-run node publish.mjs -p graph/${{ inputs.src }} -t ${{ inputs.trace }}
+          xvfb-run node publish.mjs -p graph/${{ inputs.src }} -t ${{ inputs.trace }} -o graph-www
           exit $?
     - name: Archive trace file
       if: ${{ always() && inputs.trace }}

--- a/publish.mjs
+++ b/publish.mjs
@@ -13,6 +13,10 @@ async function main() {
       alias: "p",
       type: "string",
     })
+    .option("output", {
+      alias: "o",
+      type: "string",
+    })
     .option("trace", {
       alias: "t",
       type: "boolean",
@@ -21,7 +25,7 @@ async function main() {
     .parse();
 
   const graphPath = path.resolve(process.cwd(), argv.path);
-  const graphDistPath = path.resolve(process.cwd(), graphPath + "-www");
+  const graphDistPath = path.resolve(process.cwd(), argv.output || (graphPath + "-www"));
 
   const traceFile = path.join(graphDistPath, "trace.zip");
 


### PR DESCRIPTION
Sorry for the mistake I made in PR #11 . The arg `path` for `publish.mjs` would also change the output path, likes `/home/logseq/graph/docs-www`. It made dest volume path `/home/logseq/graph-www` empty.
This patch should make it work as expected, have been tested with `ghcr.io/imyelo/logseq-publish:beta`.