### PR TITLE
Update dockerfile to fix workspaces failure

### DIFF
--- a/Dockerfile.logseq
+++ b/Dockerfile.logseq
@@ -19,7 +19,7 @@ WORKDIR /data/
 
 # Build for static resources
 RUN git clone --depth 1 --branch $LOGSEQ_TAG --single-branch https://github.com/logseq/logseq.git
-RUN cd /data/logseq && git rev-parse HEAD && yarn && yarn release && mv ./static ./public && rm -r ./public/workspaces
+RUN cd /data/logseq && git rev-parse HEAD && yarn && yarn release && mv ./static ./public
 
 # From playwright
 # https://playwright.dev/docs/docker/


### PR DESCRIPTION
@pengx17 Hi. I'd like to use the latest 0.8.8 logseq on the official docs. I see [the nightly builds started failing](https://github.com/pengx17/logseq-publish/actions) close to when https://github.com/logseq/logseq/pull/6696 landed. This should fix the nightly build. Thanks for this great project! Cheers