### PR TITLE
Fix outdated command that causes failure

### DIFF
--- a/Dockerfile.logseq
+++ b/Dockerfile.logseq
@@ -37,4 +37,4 @@ COPY --from=builder /data/logseq/public ./public
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm i
 
-RUN cd ./public/static && yarn install && yarn rebuild:better-sqlite3
+RUN cd ./public/static && yarn install && yarn rebuild:all


### PR DESCRIPTION
@pengx17 Hi. I noticed the [builds started failing again](https://github.com/pengx17/logseq-publish/actions). This should fix the nightly build and allow official docs to publish correctly again. Cheers